### PR TITLE
Android sdk 22 fixes

### DIFF
--- a/library/project.properties
+++ b/library/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-16
+target=android-18
 android.library=true
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
                 <plugin>
                     <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                     <artifactId>android-maven-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <sdk>
                             <platform>${android.platform}</platform>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <java.version>1.6</java.version>
         <android.version>4.1.1.4</android.version>
-        <android.platform>16</android.platform>
+        <android.platform>18</android.platform>
     </properties>
 
     <dependencyManagement>

--- a/samples/project.properties
+++ b/samples/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}\tools\proguard\proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-16
+target=android-18
 android.library.reference.1=../library


### PR DESCRIPTION
The current master doesn't build with the Android SDK 22, dying on `Could not find tool 'aapt'` errors.

The new android maven plugin addresses this.
In addition, android-18 is probably a reasonable target API level at this time.
